### PR TITLE
CleanJets changes from cfg->cfi

### DIFF
--- a/CleanJets/cleanjets_cfg.py
+++ b/CleanJets/cleanjets_cfg.py
@@ -12,34 +12,22 @@ process.load('Configuration.Geometry.GeometryRecoDB_cff')
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_condDBv2_cff')
 process.load('TrackingTools.TransientTrack.TransientTrackBuilder_cfi')
 process.GlobalTag.globaltag = cms.string('74X_dataRun2_Prompt_v3')
+process.load("Tools.CleanJets.cleanjets_cfi")
+
 
 #######################################
 # Declaring Input and configurations
 #######################################
 process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(-1) )
 process.source = cms.Source("PoolSource",
-         fileNames = cms.untracked.vstring('root://eoscms//eos/cms/store/user/mshi/gg2H2aa2mumutautau_STEP_2_9GeV/gg2H2aa2mumutautau_STEP_2_9GeV_NUM.root')
+         fileNames = cms.untracked.vstring('root://eoscms//eos/cms/store/user/mshi/gg2H2aa2mumutautau_STEP_2_9GeV/gg2H2aa2mumutautau_STEP_2_9GeV_978.root')
 )
 
-#########################################################
-# this will produce a ref to the original muon collection
-#########################################################
-process.muonsRef = cms.EDFilter('MuonRefSelector',
-                   src = cms.InputTag('muons'),
-                   cut = cms.string('pt > 0.0'),
-                   filter = cms.bool(True)
-)
 
-#############################
-# Clean Jets Definition
-##############################
-process.CleanJets = cms.EDProducer(
-    'CleanJets',
-    jetSrc = cms.InputTag("ak4PFJets"),
-    muonSrc = cms.InputTag("muonsRef"),
-    PFCandSrc = cms.InputTag("pfIsolatedMuonsEI"),
-    outFileName = cms.string('file:/afs/cern.ch/user/k/ktos/NMSSM_Analysis/CMSSW_7_4_12_patch4/src/Tools/CleanJets/BSUB/DIRNAME/CleanJets_Plots.root')
-)
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(-1) )
+
+#process.p = cms.Path(process.CleanJets)
+
 
 #######################################
 # HPS Tau Reconstruction alterations 
@@ -56,11 +44,12 @@ process.combinatoricRecoTaus.jetSrc = cms.InputTag('CleanJets', 'ak4PFJetsNoMu',
 # Configuring Output
 #######################################
 process.out = cms.OutputModule("PoolOutputModule",
-    fileName = cms.untracked.string('file:DIRNAME_NUM.root'),
+    fileName = cms.untracked.string('file:TEST.root'),
     SelectEvents = cms.untracked.PSet(SelectEvents = cms.vstring('p')),
 )
 
 process.p = cms.Path(process.muonsRef*
-		     process.CleanJets*
-	             process.PFTau)
+                     process.CleanJets*
+                     process.PFTau)
 process.e = cms.EndPath(process.out)
+

--- a/CleanJets/python/cleanjets_cfi.py
+++ b/CleanJets/python/cleanjets_cfi.py
@@ -1,12 +1,22 @@
 import FWCore.ParameterSet.Config as cms
 
+
+#########################################################
+# this will produce a ref to the original muon collection
+#########################################################
+muonsRef = cms.EDFilter('MuonRefSelector',
+                   src = cms.InputTag('muons'),
+                   cut = cms.string('pt > 0.0'),
+                   filter = cms.bool(True)
+)
+
+#############################
+# Clean Jets Definition
+##############################
 CleanJets = cms.EDProducer(
     'CleanJets',
-    jetSrc = cms.InputTag("ak5PFJets"),
-    outFileName = cms.string('/data1/friccita/NMSSMSignalWH_MuProperties.root'),
-    momPDGID = cms.uint32(36),
-    genMuTauPTMin = cms.double(0.0), #GeV
-    genMuPTMin = cms.double(20.0), #GeV                           
-    cutOnGenMatches = cms.bool(True),
-    thisTag = cms.InputTag('CleanJets', 'ak5PFJetsNoMu', 'ANALYSIS')
-    )
+    jetSrc = cms.InputTag("ak4PFJets"),
+    muonSrc = cms.InputTag("muonsRef"),
+    PFCandSrc = cms.InputTag("pfIsolatedMuonsEI"),
+    outFileName = cms.string('file:/afs/cern.ch/user/k/ktos/NMSSM_Analysis/CMSSW_7_4_12_patch4/src/Tools/CleanJets/BSUB/DIRNAME/CleanJets_Plots.root')
+)


### PR DESCRIPTION
This should fix the problem with the cfg and cfi files in the skimmer. Also, in the skimmer file tauSelectionSkim_MC.py, lines 309-324 need to be changed. I believe it should look something like what is listed below (although I need to double check the MuonSrc with Rachel/Francesca in the skimmer to be certain. Feel free to try it before I get the verification, since I'm about 95% sure it should be fine)

process.CleanJets.muonSrc = cms.InputTag('MuonIWant')
process.CleanJets.PFCandSrc = cms.InputTag('pfIsolatedMuonsEI')
process.CleanJets.outFileName = cms.string('NMSSMSignal_MuProperties.root') 
## I don't know if you want to keep the plots, since they are mostly used for my verification of ##CleanJets. If not, then 2 make this outFileName to some trash directory.

process.ak4PFJetTracksAssociatorAtVertex.jets = cms.InputTag('CleanJets', 'ak4PFJetsNoMu', 'CLEANJETS')
process.recoTauAK4PFJets08Region.src = cms.InputTag('CleanJets', 'ak4PFJetsNoMu', 'CLEANJETS')
process.ak4PFJetsLegacyHPSPiZeros.jetSrc = cms.InputTag('CleanJets', 'ak4PFJetsNoMu', 'CLEANJETS')
process.ak4PFJetsRecoTauChargedHadrons.jetSrc = cms.InputTag('CleanJets', 'ak4PFJetsNoMu', 'CLEANJETS')
process.combinatoricRecoTaus.jetSrc = cms.InputTag('CleanJets', 'ak4PFJetsNoMu', 'CLEANJETS')

process.recoTauCommonSequence = cms.Sequence(process.CleanJets*
                                                                                       process.ak4PFJetTracksAssociatorAtVertex*
                                                                                       process.recoTauAK4PFJets08Region*
                                                                                       process.recoTauPileUpVertices*
                                                                                       process.pfRecoTauTagInfoProducer
                                                                                      )  
process.PFTau = cms.Sequence(process.recoTauCommonSequence*process.recoTauClassicHPSSequence)
